### PR TITLE
Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 .idea/
 coverage.txt
 k8s-image-swapper
+__debug_bin
+.vscode/launch.json

--- a/.k8s-image-swapper.yml
+++ b/.k8s-image-swapper.yml
@@ -39,9 +39,9 @@ source:
 target:
   type: aws
   aws:
-    accountId: 123456789
+    accountId: 123456789101
     region: ap-southeast-2
-    role: arn:aws:iam::123456789012:role/roleName
+    # role: arn:aws:iam::123456789012:role/roleName
     ecrOptions:
       tags:
         - key: CreatedBy

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,11 +73,13 @@ A mutating webhook for Kubernetes, pointing the images to a new location.`,
 
 		imageSwapPolicy, err := types.ParseImageSwapPolicy(cfg.ImageSwapPolicy)
 		if err != nil {
+			metrics.IncrementError("ParseImageSwapPolicyFail")
 			log.Err(err)
 		}
 
 		imageCopyPolicy, err := types.ParseImageCopyPolicy(cfg.ImageCopyPolicy)
 		if err != nil {
+			metrics.IncrementError("imageCopyPolicyFail")
 			log.Err(err)
 		}
 
@@ -92,6 +94,7 @@ A mutating webhook for Kubernetes, pointing the images to a new location.`,
 		)
 		if err != nil {
 			log.Err(err).Msg("error creating webhook")
+			metrics.IncrementError("NewImageSwapperWebhookWithOptsFail")
 			os.Exit(1)
 		}
 
@@ -239,6 +242,7 @@ func initConfig() {
 
 	if err := viper.Unmarshal(&cfg); err != nil {
 		log.Err(err).Msg("failed to unmarshal the config file")
+		metrics.IncrementError("ConfigUnmarshalFail")
 	}
 
 	//validate := validator.New()
@@ -273,12 +277,14 @@ func setupImagePullSecretsProvider() secrets.ImagePullSecretsProvider {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to configure Kubernetes client, will continue without reading secrets")
+		metrics.IncrementError("setupImagePullSecretsProviderFail")
 		return secrets.NewDummyImagePullSecretsProvider()
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to configure Kubernetes client, will continue without reading secrets")
+		metrics.IncrementError("setupImagePullSecretsProviderFail")
 		return secrets.NewDummyImagePullSecretsProvider()
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,22 +28,13 @@ import (
 )
 
 var (
-	metricLabels  = []string{"namespace", "registry", "repo"}
-	swapperErrors = prometheus.NewCounterVec(
+	metricLabels = []string{"namespace", "registry", "repo"}
+	ecrErrors    = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "k8s_image_swapper",
-			Subsystem: "swapping",
+			Subsystem: "ecr",
 			Name:      "errors",
-			Help:      "Number of errors",
-		},
-		metricLabels,
-	)
-	numberOfSwaps = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "k8s_image_swapper",
-			Subsystem: "swaping",
-			Name:      "swaps",
-			Help:      "Number of swaps for the repo",
+			Help:      "Number of ecr errors",
 		},
 		metricLabels,
 	)
@@ -54,20 +45,17 @@ var PromReg *prometheus.Registry
 func init() {
 	PromReg = prometheus.NewRegistry()
 	PromReg.MustRegister(collectors.NewGoCollector())
-	PromReg.MustRegister(swapperErrors)
-	PromReg.MustRegister(numberOfSwaps)
-
+	PromReg.MustRegister(ecrErrors)
 }
 
-// PrometheusMetricServer the type of MetricsServer
-type PrometheusMetricServer struct{}
-
-// RecordSwapError counts the number of swapping errors
-func (metricsServer PrometheusMetricServer) RecordSwapError(namespace string, registry string, repo string) {
-	labels := getLabels(namespace, registry, repo)
-	swapperErrors.With(labels).Inc()
-}
-
-func getLabels(namespace string, registry string, repo string) prometheus.Labels {
-	return prometheus.Labels{"namespace": namespace, "registry": registry, "repo": repo}
+// Increments the counter of ecr errors
+func IncrementEcrError(resource_namespace string, registry string, repo string, errType string) {
+	ecrErrors.With(
+		prometheus.Labels{
+			"resource_namespace": resource_namespace,
+			"registry":           registry,
+			"repo":               repo,
+			"error_type":         errType,
+		},
+	).Inc()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,6 +28,15 @@ import (
 )
 
 var (
+	errors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "k8s_image_swapper",
+			Subsystem: "main",
+			Name:      "errors",
+			Help:      "Number of errors",
+		},
+		[]string{"error_type"},
+	)
 	metricLabels = []string{"resource_namespace", "registry", "repo", "error_type"}
 	ecrErrors    = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -48,9 +57,18 @@ func init() {
 	PromReg.MustRegister(ecrErrors)
 }
 
+// Increments the counter of errors
+func IncrementError(errType string) {
+	ecrErrors.With(
+		prometheus.Labels{
+			"error_type": errType,
+		},
+	).Inc()
+}
+
 // Increments the counter of ecr errors
 func IncrementEcrError(resource_namespace string, registry string, repo string, errType string) {
-	ecrErrors.With(
+	errors.With(
 		prometheus.Labels{
 			"resource_namespace": resource_namespace,
 			"registry":           registry,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,73 @@
+/*
+Copyright © 2020 Enrico Stahn <enrico.stahn@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+var (
+	metricLabels  = []string{"namespace", "registry", "repo"}
+	swapperErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "k8s_image_swapper",
+			Subsystem: "swapping",
+			Name:      "errors",
+			Help:      "Number of errors",
+		},
+		metricLabels,
+	)
+	numberOfSwaps = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "k8s_image_swapper",
+			Subsystem: "swaping",
+			Name:      "swaps",
+			Help:      "Number of swaps for the repo",
+		},
+		metricLabels,
+	)
+)
+
+var PromReg *prometheus.Registry
+
+func init() {
+	PromReg = prometheus.NewRegistry()
+	PromReg.MustRegister(collectors.NewGoCollector())
+	PromReg.MustRegister(swapperErrors)
+	PromReg.MustRegister(numberOfSwaps)
+
+}
+
+// PrometheusMetricServer the type of MetricsServer
+type PrometheusMetricServer struct{}
+
+// RecordSwapError counts the number of swapping errors
+func (metricsServer PrometheusMetricServer) RecordSwapError(namespace string, registry string, repo string) {
+	labels := getLabels(namespace, registry, repo)
+	swapperErrors.With(labels).Inc()
+}
+
+func getLabels(namespace string, registry string, repo string) prometheus.Labels {
+	return prometheus.Labels{"namespace": namespace, "registry": registry, "repo": repo}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	metricLabels = []string{"namespace", "registry", "repo"}
+	metricLabels = []string{"resource_namespace", "registry", "repo", "error_type"}
 	ecrErrors    = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "k8s_image_swapper",

--- a/pkg/secrets/kubernetes.go
+++ b/pkg/secrets/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/estahn/k8s-image-swapper/pkg/metrics"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
@@ -73,6 +74,7 @@ func (p *KubernetesImagePullSecretsProvider) GetImagePullSecrets(pod *v1.Pod) (*
 		Get(context.TODO(), pod.Spec.ServiceAccountName, metav1.GetOptions{})
 	if err != nil {
 		log.Err(err).Msg("error fetching referenced service account, continue without service account imagePullSecrets")
+		metrics.IncrementError("kubernetesClientFail")
 	}
 
 	if serviceAccount != nil {
@@ -89,6 +91,7 @@ func (p *KubernetesImagePullSecretsProvider) GetImagePullSecrets(pod *v1.Pod) (*
 		secret, err := p.kubernetesClient.CoreV1().Secrets(pod.Namespace).Get(context.TODO(), imagePullSecret.Name, metav1.GetOptions{})
 		if err != nil {
 			log.Err(err).Msg("error fetching secret, continue without imagePullSecrets")
+			metrics.IncrementError("kubernetesClientFail")
 		}
 
 		if secret == nil || secret.Type != v1.SecretTypeDockerConfigJson {

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -312,6 +312,7 @@ func filterMatch(ctx FilterContext, filters []config.JMESPathFilter) bool {
 
 		if err != nil {
 			log.Err(err).Str("filter", filter.JMESPath).Msgf("Filter (idx %v) could not be evaluated.", idx)
+			metrics.IncrementError("FilterEvalFail")
 			return false
 		}
 
@@ -322,6 +323,7 @@ func filterMatch(ctx FilterContext, filters []config.JMESPathFilter) bool {
 			}
 		default:
 			log.Warn().Str("filter", filter.JMESPath).Msg("filter does not return a bool value")
+			metrics.IncrementError("FilterEvalFail")
 		}
 	}
 


### PR DESCRIPTION
Built-in metrics provided by `kubewebhook` have hardcoded names, ends up being something like
```
kubewebhook_mutating_webhook_review_duration_seconds_bucket{dry_run="false",mutated="true",operation="create",resource_kind="v1/Pod",resource_namespace="kube-system",success="true",webhook_id="k8s-image-swapper",webhook_version="v1beta1",le="1"} 2
```
Not sure if that's an issue, but other metrics will have different name (and prom "namespace") structure, example
```
k8s_image_swapper_ecr_errors{resource_namespace="default",registry="docker.io",repo="alpine",error_type="CreateRepositoryFail"} 1
```
